### PR TITLE
Bump module dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,24 +9,24 @@
   "issues_url": "https://github.com/derdanne/puppet-nfs/issues",
   "dependencies": [
     {
-      "name":"puppetlabs/stdlib",
-      "version_requirement":">= 4.5.0 < 10.0.0"
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 4.5.0 < 10.0.0"
     },
     {
-      "name":"puppetlabs/concat",
-      "version_requirement":">= 1.1.2 < 10.0.0"
+      "name": "puppetlabs/concat",
+      "version_requirement": ">= 1.1.2 < 10.0.0"
     },
     {
-      "name":"puppetlabs/transition",
-      "version_requirement":">= 0.1.0 < 3.0.0"
+      "name": "puppetlabs/transition",
+      "version_requirement": ">= 0.1.0 < 3.0.0"
     },
     {
-      "name":"puppet/augeasproviders_core",
-      "version_requirement":">= 2.1.5 < 5.0.0"
+      "name": "puppet/augeasproviders_core",
+      "version_requirement": ">= 2.1.5 < 5.0.0"
     },
     {
-      "name":"puppet/augeasproviders_shellvar",
-      "version_requirement":">= 1.2.0 < 7.0.0"
+      "name": "puppet/augeasproviders_shellvar",
+      "version_requirement": ">= 1.2.0 < 7.0.0"
     }
   ],
   "tags": ["nfs", "nfs4", "exports", "mount", "mfc"],

--- a/metadata.json
+++ b/metadata.json
@@ -8,11 +8,26 @@
   "project_page": "https://github.com/derdanne/puppet-nfs",
   "issues_url": "https://github.com/derdanne/puppet-nfs/issues",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 4.5.0 < 9.0.0"},
-    {"name":"puppetlabs/concat","version_requirement":">= 1.1.2 < 8.0.0"},
-    {"name":"puppetlabs/transition","version_requirement":">= 0.1.0 < 2.0.0"},
-    {"name":"puppet/augeasproviders_core","version_requirement":">= 2.1.5 < 4.0.0"},
-    {"name":"puppet/augeasproviders_shellvar","version_requirement":">= 1.2.0 <= 5.0.0"}
+    {
+      "name":"puppetlabs/stdlib",
+      "version_requirement":">= 4.5.0 < 10.0.0"
+    },
+    {
+      "name":"puppetlabs/concat",
+      "version_requirement":">= 1.1.2 < 10.0.0"
+    },
+    {
+      "name":"puppetlabs/transition",
+      "version_requirement":">= 0.1.0 < 3.0.0"
+    },
+    {
+      "name":"puppet/augeasproviders_core",
+      "version_requirement":">= 2.1.5 < 5.0.0"
+    },
+    {
+      "name":"puppet/augeasproviders_shellvar",
+      "version_requirement":">= 1.2.0 < 7.0.0"
+    }
   ],
   "tags": ["nfs", "nfs4", "exports", "mount", "mfc"],
   "operatingsystem_support": [


### PR DESCRIPTION
Reformat module dependencies for legibility and forward compatibility
with PDK layout.

Bump stdlib to < 10
Bump concat to < 10
Bump transition to < 3
Bump augeus core to < 4
Bump augues sheelvar to < 7

Fixes: GH-168