### PR TITLE
Fix syntax for puppet-strings @example.

### DIFF
--- a/manifests/server/export.pp
+++ b/manifests/server/export.pp
@@ -57,7 +57,7 @@
 # @param v4_export_name
 # @param nfsv4_bindmount_enable
 #
-# @examples
+# @example
 #
 # class { '::nfs':
 #   server_enabled             => true,


### PR DESCRIPTION
The correct syntax is @example.
