### PR TITLE
move static data from params.pp to init.pp

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -156,7 +156,7 @@ Data type: `Boolean`
 Boolean. If set to <tt>true</tt>, this module will use nfs version 4
 for exporting and mounting nfs resources.
 
-Default value: `$nfs::params::nfs_v4`
+Default value: `false`
 
 ##### <a name="-nfs--nfs_v4_client"></a>`nfs_v4_client`
 
@@ -166,7 +166,7 @@ Boolean. If set to <tt>true</tt>, this module will use nfs version 4
 for mounting nfs resources. If set to <tt>false</tt> it will use nfs
 version 3 to mount nfs resources. It defaults to the setting of @param nfs_v4
 
-Default value: `$nfs::params::nfs_v4`
+Default value: `false`
 
 ##### <a name="-nfs--exports_file"></a>`exports_file`
 
@@ -395,7 +395,7 @@ Data type: `String`
 String. It defines the location where nfs version 4 exports should be bindmounted to
 on a server node. Defaults to <tt>/export</tt>.
 
-Default value: `$nfs::params::nfs_v4_export_root`
+Default value: `'/export'`
 
 ##### <a name="-nfs--nfs_v4_export_root_clients"></a>`nfs_v4_export_root_clients`
 
@@ -405,7 +405,7 @@ String. It defines the clients that are allowed to mount nfs version 4 exports a
 includes the option string. Defaults to
 <tt>*.${::domain}(ro,fsid=root,insecure,no_subtree_check,async,root_squash)</tt>.
 
-Default value: `$nfs::params::nfs_v4_export_root_clients`
+Default value: `"*.${facts['networking']['domain']}(ro,fsid=root,insecure,no_subtree_check,async,root_squash)"`
 
 ##### <a name="-nfs--nfs_v4_mount_root"></a>`nfs_v4_mount_root`
 
@@ -414,7 +414,7 @@ Data type: `String`
 String. It defines the location where nfs version 4 clients find the mount root
 on a server node. Defaults to <tt>/srv</tt>.
 
-Default value: `$nfs::params::nfs_v4_mount_root`
+Default value: `'/srv'`
 
 ##### <a name="-nfs--nfs_v4_idmap_domain"></a>`nfs_v4_idmap_domain`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -128,7 +128,7 @@
 # @param nfs_v4_idmap_nobody_user
 #   String. 'Nobody-User' option for idmapd. Defaults to <tt>nobody</tt>.
 # @param nfs_v4_idmap_nobody_group
-#   String. 'Nobody-Group' option for idmapd. Defaults to <tt>nobody</tt> or <tt>nogroup</tt>. 
+#   String. 'Nobody-Group' option for idmapd. Defaults to <tt>nobody</tt> or <tt>nogroup</tt>.
 # @param client_rpcbind_config
 #   String. It defines the location of the file with the rpcbind config.
 # @param client_rpcbind_optname
@@ -169,8 +169,8 @@ class nfs (
   Boolean                                                     $server_enabled                     = false,
   Boolean                                                     $client_enabled                     = false,
   Boolean                                                     $storeconfigs_enabled               = true,
-  Boolean                                                     $nfs_v4                             = $nfs::params::nfs_v4,
-  Boolean                                                     $nfs_v4_client                      = $nfs::params::nfs_v4,
+  Boolean                                                     $nfs_v4                             = false,
+  Boolean                                                     $nfs_v4_client                      = false,
   Stdlib::Absolutepath                                        $exports_file                       = $nfs::params::exports_file,
   Stdlib::Absolutepath                                        $idmapd_file                        = $nfs::params::idmapd_file,
   Optional[Stdlib::Absolutepath]                              $defaults_file                      = $nfs::params::defaults_file,
@@ -205,9 +205,9 @@ class nfs (
   String                                                      $client_gssd_options                = $nfs::params::client_gssd_options,
   String                                                      $client_gssdopt_name                = $nfs::params::client_gssdopt_name,
   Boolean                                                     $client_d9_gssdopt_workaround       = false,
-  String                                                      $nfs_v4_export_root                 = $nfs::params::nfs_v4_export_root,
-  String                                                      $nfs_v4_export_root_clients         = $nfs::params::nfs_v4_export_root_clients,
-  String                                                      $nfs_v4_mount_root                  = $nfs::params::nfs_v4_mount_root,
+  String                                                      $nfs_v4_export_root                 = '/export',
+  String                                                      $nfs_v4_export_root_clients         = "*.${facts['networking']['domain']}(ro,fsid=root,insecure,no_subtree_check,async,root_squash)",
+  String                                                      $nfs_v4_mount_root                  = '/srv',
   String                                                      $nfs_v4_idmap_domain                = $nfs::params::nfs_v4_idmap_domain,
   Variant[String, Array]                                      $nfs_v4_idmap_localrealms           = '', # lint:ignore:params_empty_string_assignment
   Integer                                                     $nfs_v4_idmap_cache                 = 0,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,11 +15,6 @@
 class nfs::params {
   #### Default values for the parameters of the main module class, init.pp
 
-  $nfs_v4                     = false
-  $nfs_v4_export_root         = '/export'
-  $nfs_v4_export_root_clients = "*.${facts['networking']['domain']}(ro,fsid=root,insecure,no_subtree_check,async,root_squash)"
-  $nfs_v4_mount_root          = '/srv'
-
   if $facts['networking']['domain'] != undef {
     $nfs_v4_idmap_domain = $facts['networking']['domain']
   } else {


### PR DESCRIPTION
This enables puppet-strings to pickup the data and helps to reduce the params.pp size.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
