### PR TITLE
Drop Debian 10 support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -112,7 +112,7 @@ class nfs::params {
           $server_service_name        = 'nfs-kernel-server'
           $client_gssdopt_name        = 'RPCGSSDOPTS'
         }
-        'bullseye', 'buster', 'stretch', 'xenial', 'yakkety', 'zesty': {
+        'bullseye', 'stretch', 'xenial', 'yakkety', 'zesty': {
           $client_services            = { 'rpcbind' => {
               ensure => 'running',
               enable => false,

--- a/metadata.json
+++ b/metadata.json
@@ -28,7 +28,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10",
         "11"
       ]
     },

--- a/spec/classes/nfs_spec.rb
+++ b/spec/classes/nfs_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe 'nfs' do
   # supported_os = %w[Ubuntu_default Ubuntu_16.04 Debian_default Debian_8 RedHat_default RedHat_7 RedHat_75 RedHat_8 Gentoo SLES Archlinux]
-  supported_os = %w[Ubuntu_20.04 Ubuntu_22.04 Debian_10 Debian_11 RedHat_default RedHat_7 RedHat_75 RedHat_8 Gentoo SLES]
+  supported_os = %w[Ubuntu_20.04 Ubuntu_22.04 Debian_11 RedHat_default RedHat_7 RedHat_75 RedHat_8 Gentoo SLES]
   supported_os.each do |os|
     context os do
       let(:default_facts) do
@@ -248,36 +248,6 @@ describe 'nfs' do
               'release' => {
                 'major' => '9',
                 'full' => '9'
-              }
-            }
-          )
-        end
-
-        server_service = 'nfs-kernel-server'
-        server_servicehelpers = %w[nfs-idmapd]
-        server_packages = %w[nfs-common nfs-kernel-server nfs4-acl-tools rpcbind]
-        client_services = %w[rpcbind]
-        client_nfs_vfour_services = %w[rpcbind]
-        client_packages = %w[nfs-common nfs4-acl-tools]
-        client_gssdopt_name = 'GSSDARGS'
-        defaults_file = '/etc/default/nfs-common'
-        idmapd_file = '/etc/idmapd.conf'
-        client_rpcbind_config = '/etc/default/rpcbind'
-        client_rpcbind_optname = 'OPTIONS'
-
-      when 'Debian_10'
-
-        let(:facts) do
-          default_facts.merge(
-            'operatingsystem' => 'Debian',
-            'os' => {
-              'family' => 'Debian',
-              'distro' => {
-                'codename' => 'buster'
-              },
-              'release' => {
-                'major' => '10',
-                'full' => '10'
               }
             }
           )


### PR DESCRIPTION
Debian 10 is already EoL, so we should drop it.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
