### PR TITLE
Allow export clients to be Array

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1147,7 +1147,7 @@ The following parameters are available in the `nfs::server::export` defined type
 
 ##### <a name="-nfs--server--export--clients"></a>`clients`
 
-Data type: `String[1]`
+Data type: `Variant[String[1],Array[String[1]]]`
 
 Sets the allowed clients and options for the export in the exports file.
 

--- a/manifests/server/export.pp
+++ b/manifests/server/export.pp
@@ -67,7 +67,7 @@
 define nfs::server::export (
   String[1]           $v3_export_name         = $name,
   String[1]           $v4_export_name         = regsubst($name, '.*/(.*)', '\1' ),
-  String[1]           $clients                = 'localhost(ro)',
+  Variant[String[1],Array[String[1]]] $clients = 'localhost(ro)',
   String[1]           $bind                   = 'rbind',
   # globals for this share
   # propogated to storeconfigs


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

The `clients` parameter of `nfs::server::export` can be an array according to `nfs::functions::create_export`. 


#### This Pull Request (PR) fixes the following issues

Allow `clients` to be the same datatype in `nfs::server::export`  and `nfs::functions::create_export`
