### PR TITLE
Add RHEL/CentOS 10 support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -188,24 +188,7 @@ class nfs::params {
           $server_nfsv4_servicehelper = ['nfs-idmap.service']
           $server_service_name        = 'nfs-server.service'
         }
-        '8': {
-          $client_idmapd_setting      = ['']
-          $client_nfs_options         = 'tcp,nolock,rsize=32768,wsize=32768,intr,noatime,actimeo=3'
-          $client_services_enable     = true
-          $client_gssdopt_name        = 'RPCGSSDARGS'
-          $client_services            = { 'rpcbind.service' => {} }
-          $client_gssd_service_name   = { 'rpc-gssd' => {
-              ensure => 'running',
-              enable => true,
-            },
-          }
-          $client_nfsv4_fstype        = 'nfs4'
-          $client_nfsv4_options       = 'tcp,nolock,rsize=32768,wsize=32768,intr,noatime,actimeo=3'
-          $client_nfsv4_services      = { 'rpcbind' => {} }
-          $server_nfsv4_servicehelper = ['nfs-idmapd.service']
-          $server_service_name        = 'nfs-server.service'
-        }
-        '9': {
+        '8', '9', '10': {
           $client_idmapd_setting      = ['']
           $client_nfs_options         = 'tcp,nolock,rsize=32768,wsize=32768,intr,noatime,actimeo=3'
           $client_services_enable     = true

--- a/metadata.json
+++ b/metadata.json
@@ -64,14 +64,16 @@
       "operatingsystemrelease": [
         "7",
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {


### PR DESCRIPTION
RHEL 8, 9 and 10 NFSv4 options are the same, so this we can condense the params switch case.
